### PR TITLE
dependabot ignore for `k8s.io/*`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "gomod"
+    directory: "/magefiles/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "k8s.io/*"


### PR DESCRIPTION
Added ignore for k8s.io/* to avoid updates that are incompatible with the kubebuilder plugin.